### PR TITLE
Add bin and config files for SLURM job submission system

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,20 @@ Details on setting-up the sequencing parameters for NuGEN are described in Secti
   `snakemake -s $MOTRPAC_root/rna-seq.snakefile`
 * If the data is for rat samples, run the command below for the rat genome `rn6_ensembl_r95`  
   `snakemake -s $MOTRPAC_root/rna-seq.snakefile --config genome=rn6_ensembl_r95`
-* If the snakemake is running OK locally, then submit the snakemake jobs to the cluster. This is only necessary for large jobs. This script was written for Sinai LSF jobs submission system. Other cluster job submission system may need to write their own script.  
-  `Snakemake.lsf -- -s $MOTRPAC_root/rna-seq.snakefile --config genome=rn6_ensembl_r95`
+  
+### B.2.1 Run the snakemake on a cluster
+If the snakemake is running OK locally, then submit the snakemake jobs to the cluster. This is only necessary for large jobs. These scripts were written for Sinai LSF and Stanford SLURM job submission systems. Other cluster job submission systems may need to write their own scripts and configuration files (`$MOTRPAC_root/config/`). 
+
+**For the Sinai LSF job submission system:**  
+```
+bash $MOTRPAC_root/bin/Snakemake_lsf.sh -- -s $MOTRPAC_root/rna-seq.snakefile --config genome=rn6_ensembl_r95
+```
+**For a SLURM job submission system (e.g. SCG Informatics Cluster):**  
+Where `${genome}` is defined as `hg38_gencode_v29` for human RNA-seq data or `rn6_ensembl_r95` for rat RNA-seq data, run the following command to run the pipeline with `sbatch`:
+```
+bash $MOTRPAC_root/bin/Snakemake_slurm.sh ${genome} ${outdir}
+```
+Change `SBATCH` options as needed in `$MOTRPAC_root/config/slurm.json`. 
 
 # *Code implementation philosophy 
 * The default uses `python3`, while a few tools relies on `python2`. Both python3 and python2 co-exists peacefully by calling `python2` for python2 specific scripts.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ bash $MOTRPAC_root/bin/Snakemake_lsf.sh -- -s $MOTRPAC_root/rna-seq.snakefile --
 **For a SLURM job submission system (e.g. SCG Informatics Cluster):**  
 * Where `${genome}` is defined as `hg38_gencode_v29` for human RNA-seq data or `rn6_ensembl_r95` for rat RNA-seq data, run the following command to run the pipeline with `sbatch`:  
 ```
-bash $MOTRPAC_root/bin/Snakemake_slurm.sh ${genome} ${outdir}`  
+bash $MOTRPAC_root/bin/Snakemake_slurm.sh ${genome} ${outdir} 
 ```
 * Change `SBATCH` options as needed in `$MOTRPAC_root/config/slurm.json`.   
 

--- a/README.md
+++ b/README.md
@@ -89,23 +89,20 @@ Details on setting-up the sequencing parameters for NuGEN are described in Secti
 
 ### B.2.1 Run the snakemake locally  
 * Run the command locally to debug possible problems below for the human genome  
-  `snakemake -s $MOTRPAC_root/rna-seq.snakefile`
+  `snakemake -s $MOTRPAC_root/rna-seq.snakefile`  
 * If the data is for rat samples, run the command below for the rat genome `rn6_ensembl_r95`  
-  `snakemake -s $MOTRPAC_root/rna-seq.snakefile --config genome=rn6_ensembl_r95`
+  `snakemake -s $MOTRPAC_root/rna-seq.snakefile --config genome=rn6_ensembl_r95`  
   
 ### B.2.2 Run the snakemake on a cluster
 If the snakemake is running OK locally, then submit the snakemake jobs to the cluster. This is only necessary for large jobs. These scripts were written for Sinai LSF and Stanford SLURM job submission systems. Other cluster job submission systems may need to write their own scripts and configuration files (`$MOTRPAC_root/config/`). 
 
 **For the Sinai LSF job submission system:**  
-```
-bash $MOTRPAC_root/bin/Snakemake_lsf.sh -- -s $MOTRPAC_root/rna-seq.snakefile --config genome=rn6_ensembl_r95
-```
+  `bash $MOTRPAC_root/bin/Snakemake_lsf.sh -- -s $MOTRPAC_root/rna-seq.snakefile --config genome=rn6_ensembl_r95`
+
 **For a SLURM job submission system (e.g. SCG Informatics Cluster):**  
-Where `${genome}` is defined as `hg38_gencode_v29` for human RNA-seq data or `rn6_ensembl_r95` for rat RNA-seq data, run the following command to run the pipeline with `sbatch`:
-```
-bash $MOTRPAC_root/bin/Snakemake_slurm.sh ${genome} ${outdir}
-```
-Change `SBATCH` options as needed in `$MOTRPAC_root/config/slurm.json`. 
+* Where `${genome}` is defined as `hg38_gencode_v29` for human RNA-seq data or `rn6_ensembl_r95` for rat RNA-seq data, run the following command to run the pipeline with `sbatch`:  
+  `bash $MOTRPAC_root/bin/Snakemake_slurm.sh ${genome} ${outdir}`  
+* Change `SBATCH` options as needed in `$MOTRPAC_root/config/slurm.json`.   
 
 # *Code implementation philosophy 
 * The default uses `python3`, while a few tools relies on `python2`. Both python3 and python2 co-exists peacefully by calling `python2` for python2 specific scripts.

--- a/README.md
+++ b/README.md
@@ -97,11 +97,15 @@ Details on setting-up the sequencing parameters for NuGEN are described in Secti
 If the snakemake is running OK locally, then submit the snakemake jobs to the cluster. This is only necessary for large jobs. These scripts were written for Sinai LSF and Stanford SLURM job submission systems. Other cluster job submission systems may need to write their own scripts and configuration files (`$MOTRPAC_root/config/`). 
 
 **For the Sinai LSF job submission system:**  
-  `bash $MOTRPAC_root/bin/Snakemake_lsf.sh -- -s $MOTRPAC_root/rna-seq.snakefile --config genome=rn6_ensembl_r95`
+```
+bash $MOTRPAC_root/bin/Snakemake_lsf.sh -- -s $MOTRPAC_root/rna-seq.snakefile --config genome=rn6_ensembl_r95
+```
 
 **For a SLURM job submission system (e.g. SCG Informatics Cluster):**  
 * Where `${genome}` is defined as `hg38_gencode_v29` for human RNA-seq data or `rn6_ensembl_r95` for rat RNA-seq data, run the following command to run the pipeline with `sbatch`:  
-  `bash $MOTRPAC_root/bin/Snakemake_slurm.sh ${genome} ${outdir}`  
+```
+bash $MOTRPAC_root/bin/Snakemake_slurm.sh ${genome} ${outdir}`  
+```
 * Change `SBATCH` options as needed in `$MOTRPAC_root/config/slurm.json`.   
 
 # *Code implementation philosophy 

--- a/README.md
+++ b/README.md
@@ -86,12 +86,14 @@ Details on setting-up the sequencing parameters for NuGEN are described in Secti
 ## B.2 Run the snakemake program
 * In a work folder, a subfolder `fastq_raw` contains the fastq files of all samples `${SID}_R1.fastq.gz`, `${SID}_I1.fastq.gz` and `${SID}_R2.fastq.gz`.
 * Make sure the `MOTRPAC_root`, `PATH` and other environmental variables have been setup correctly according to section A.2
+
+### B.2.1 Run the snakemake locally  
 * Run the command locally to debug possible problems below for the human genome  
   `snakemake -s $MOTRPAC_root/rna-seq.snakefile`
 * If the data is for rat samples, run the command below for the rat genome `rn6_ensembl_r95`  
   `snakemake -s $MOTRPAC_root/rna-seq.snakefile --config genome=rn6_ensembl_r95`
   
-### B.2.1 Run the snakemake on a cluster
+### B.2.2 Run the snakemake on a cluster
 If the snakemake is running OK locally, then submit the snakemake jobs to the cluster. This is only necessary for large jobs. These scripts were written for Sinai LSF and Stanford SLURM job submission systems. Other cluster job submission systems may need to write their own scripts and configuration files (`$MOTRPAC_root/config/`). 
 
 **For the Sinai LSF job submission system:**  

--- a/bin/Snakemake_slurm.sh
+++ b/bin/Snakemake_slurm.sh
@@ -1,7 +1,9 @@
 #!/bin/bash 
 set -eux -o pipefail
 
-outdir=$1
+genome=$1
+outdir=$2
+
 indir=${outdir}/fastq_raw
 
 # export environmental variables
@@ -17,7 +19,6 @@ export PYTHONPATH=''
 # --account		"account"
 # --mail-type		"mail"
 # --output		"output"
-# --error		"error"
 
 # move to the folder where we want outputs
 cd ${outdir}
@@ -30,15 +31,14 @@ jsonfile=$MOTRPAC_root/config/slurm.json
 mkdir -p log/cluster
 
 snakemake -j 999 --snakefile $MOTRPAC_root/rna-seq.snakefile \
-					--config genome=rn6_ensembl_r95 \
 					--cluster-config $jsonfile \
+					--config genome=${genome} \
 					--cluster \
 					"sbatch --account={cluster.account} \
 						--time={cluster.time} \
 						--mem={cluster.mem} \
 						--cpus-per-task={cluster.nCPUs} \
 						--output={cluster.output} \
-						--error={cluster.error} \
 						--mail-type={cluster.mail}"
 															
 

--- a/bin/Snakemake_slurm.sh
+++ b/bin/Snakemake_slurm.sh
@@ -33,6 +33,7 @@ mkdir -p log/cluster
 snakemake -j 999 --snakefile $MOTRPAC_root/rna-seq.snakefile \
 					--cluster-config $jsonfile \
 					--config genome=${genome} \
+					--latency-wait 30 \
 					--cluster \
 					"sbatch --account={cluster.account} \
 						--time={cluster.time} \

--- a/bin/Snakemake_slurm.sh
+++ b/bin/Snakemake_slurm.sh
@@ -1,0 +1,44 @@
+#!/bin/bash 
+set -eux -o pipefail
+
+outdir=$1
+indir=${outdir}/fastq_raw
+
+# export environmental variables
+conda=/labs/smontgom/nicolerg/MOTRPAC/PIPELINES/conda
+refdata=/labs/smontgom/nicolerg/MOTRPAC/RNA/REFERENCES
+export $(/labs/smontgom/nicolerg/MOTRPAC/PIPELINES/motrpac_rnaseq/bin/load_motrpac.sh -c $conda -r $refdata)
+export PYTHONPATH=''
+
+# sbatch option		JSON cluster parameter
+# --cpus-per-task	"nCPUs"
+# --time		"time"
+# --mem			"mem"
+# --account		"account"
+# --mail-type		"mail"
+# --output		"output"
+# --error		"error"
+
+# move to the folder where we want outputs
+cd ${outdir}
+
+# make a symlink to fastq_raw in CWD called fastq_raw
+ln -sf ${indir} fastq_raw
+
+jsonfile=$MOTRPAC_root/config/slurm.json
+
+mkdir -p log/cluster
+
+snakemake -j 999 --snakefile $MOTRPAC_root/rna-seq.snakefile \
+					--config genome=rn6_ensembl_r95 \
+					--cluster-config $jsonfile \
+					--cluster \
+					"sbatch --account={cluster.account} \
+						--time={cluster.time} \
+						--mem={cluster.mem} \
+						--cpus-per-task={cluster.nCPUs} \
+						--output={cluster.output} \
+						--error={cluster.error} \
+						--mail-type={cluster.mail}"
+															
+

--- a/config/slurm.json
+++ b/config/slurm.json
@@ -1,0 +1,119 @@
+{
+    "__default__" :
+    {
+        "nCPUs"     : "1",
+        "time"      : "24:00:00",
+        "mem"       : "6G",
+        "account"   : "smontgom",
+        "name"      : "{rule}.{wildcards.sample}",
+        "mail"      : "FAIL",
+        "output"    : "log/cluster/{rule}.{wildcards.sample}.out",
+        "error"     : "log/cluster/{rule}.{wildcards.sample}.err"
+    },
+
+    "star_index" :
+    {
+        "nCPUs"     : "6",
+        "mem"       : "4G",
+        "name"      : "{rule}",
+        "output"    : "log/cluster/{rule}.out",
+        "error"     : "log/cluster/{rule}.err"
+    },
+    
+    "rsem_index" :
+    {
+        "mem"       : "36G",
+        "name"      : "{rule}",
+        "output"    : "log/cluster/{rule}.out",
+        "error"     : "log/cluster/{rule}.err"
+    },
+    "bismark_index" :
+    {
+        "mem"       : "36G",
+        "name"      : "{rule}",
+        "output"    : "log/cluster/{rule}.out",
+        "error"     : "log/cluster/{rule}.err"
+    },
+    "bowtie_index" :
+    {
+        "nCPUs"     : "6",
+        "mem"       : "6G",
+        "name"      : "{rule}",
+        "output"    : "log/cluster/{rule}.out",
+        "error"     : "log/cluster/{rule}.err"
+    },
+    
+    "star_align" :
+    {
+        "nCPUs"     : "6",
+        "mem"       : "30G"
+    },
+
+    "rRNA" :
+    {
+        "nCPUs"     : "6",
+        "mem"       : "20G"
+    },
+    "globin" :
+    {
+        "nCPUs"     : "6",
+        "mem"       : "20G"
+    },
+    "phix" :
+    {
+        "nCPUs"     : "6",
+        "mem"       : "30G"
+    },
+    "ERCC" :
+    {
+        "nCPUs"     : "6",
+        "mem"       : "20G"
+    },
+    "bowtie_align" :
+    {
+        "nCPUs"     : "6",
+        "mem"       : "30G"
+    },
+    "bismark":
+    {
+        "nCPUs"     : "12",
+        "mem"       : "20G"
+    },
+    "bismark_lambda":
+    {
+        "nCPUs"     : "12",
+        "mem"       : "20G"
+    },
+    "rsem" :
+    {
+        "nCPUs"     : "6",
+        "mem"       : "6G"
+    },
+    "qc53":
+    {
+        "mem"       : "20G"
+    },
+    "mark_dup":
+    {
+        "mem"       : "20G"
+    },
+    "qc_all":
+    {
+        "name"      : "{rule}",
+        "output"    : "log/cluster/{rule}.out",
+        "error"     : "log/cluster/{rule}.err"
+    },
+    "post_align_QC":
+    {
+        "name"      : "{rule}",
+        "output"    : "log/cluster/{rule}.out",
+        "error"     : "log/cluster/{rule}.err"
+    },
+    "pre_align_QC":
+    {
+        "name"      : "{rule}",
+        "output"    : "log/cluster/{rule}.out",
+        "error"     : "log/cluster/{rule}.err"
+    },
+}
+

--- a/config/slurm.json
+++ b/config/slurm.json
@@ -7,8 +7,7 @@
         "account"   : "smontgom",
         "name"      : "{rule}.{wildcards.sample}",
         "mail"      : "FAIL",
-        "output"    : "log/cluster/{rule}.{wildcards.sample}.out",
-        "error"     : "log/cluster/{rule}.{wildcards.sample}.err"
+        "output"    : "log/cluster/{rule}.{wildcards.sample}.out"
     },
 
     "star_index" :
@@ -16,63 +15,59 @@
         "nCPUs"     : "6",
         "mem"       : "4G",
         "name"      : "{rule}",
-        "output"    : "log/cluster/{rule}.out",
-        "error"     : "log/cluster/{rule}.err"
+        "output"    : "log/cluster/{rule}.out"
     },
     
     "rsem_index" :
     {
         "mem"       : "36G",
         "name"      : "{rule}",
-        "output"    : "log/cluster/{rule}.out",
-        "error"     : "log/cluster/{rule}.err"
+        "output"    : "log/cluster/{rule}.out"
     },
     "bismark_index" :
     {
         "mem"       : "36G",
         "name"      : "{rule}",
-        "output"    : "log/cluster/{rule}.out",
-        "error"     : "log/cluster/{rule}.err"
+        "output"    : "log/cluster/{rule}.out"
     },
     "bowtie_index" :
     {
         "nCPUs"     : "6",
         "mem"       : "6G",
         "name"      : "{rule}",
-        "output"    : "log/cluster/{rule}.out",
-        "error"     : "log/cluster/{rule}.err"
+        "output"    : "log/cluster/{rule}.out"
     },
     
     "star_align" :
     {
         "nCPUs"     : "6",
-        "mem"       : "30G"
+        "mem"       : "50G"
     },
 
     "rRNA" :
     {
         "nCPUs"     : "6",
-        "mem"       : "20G"
+        "mem"       : "40G"
     },
     "globin" :
     {
         "nCPUs"     : "6",
-        "mem"       : "20G"
+        "mem"       : "40G"
     },
     "phix" :
     {
         "nCPUs"     : "6",
-        "mem"       : "30G"
+        "mem"       : "40G"
     },
     "ERCC" :
     {
         "nCPUs"     : "6",
-        "mem"       : "20G"
+        "mem"       : "40G"
     },
     "bowtie_align" :
     {
         "nCPUs"     : "6",
-        "mem"       : "30G"
+        "mem"       : "40G"
     },
     "bismark":
     {
@@ -100,20 +95,17 @@
     "qc_all":
     {
         "name"      : "{rule}",
-        "output"    : "log/cluster/{rule}.out",
-        "error"     : "log/cluster/{rule}.err"
+        "output"    : "log/cluster/{rule}.out"
     },
     "post_align_QC":
     {
         "name"      : "{rule}",
-        "output"    : "log/cluster/{rule}.out",
-        "error"     : "log/cluster/{rule}.err"
+        "output"    : "log/cluster/{rule}.out"
     },
     "pre_align_QC":
     {
         "name"      : "{rule}",
-        "output"    : "log/cluster/{rule}.out",
-        "error"     : "log/cluster/{rule}.err"
+        "output"    : "log/cluster/{rule}.out"
     },
 }
 

--- a/config/slurm.json
+++ b/config/slurm.json
@@ -57,17 +57,17 @@
     "phix" :
     {
         "nCPUs"     : "6",
-        "mem"       : "40G"
+        "mem"       : "60G"
     },
     "ERCC" :
     {
         "nCPUs"     : "6",
-        "mem"       : "40G"
+        "mem"       : "60G"
     },
     "bowtie_align" :
     {
         "nCPUs"     : "6",
-        "mem"       : "40G"
+        "mem"       : "60G"
     },
     "bismark":
     {


### PR DESCRIPTION
Add `bin/Snakemake_slurm.sh`, `config/slurm.json`, and README documentation for running the snakemake pipeline on a SLURM job submission system such as the one for the SCG cluster.